### PR TITLE
Add support for optional range end parameter

### DIFF
--- a/lib/server/v2/commands/Get.js
+++ b/lib/server/v2/commands/Get.js
@@ -86,9 +86,9 @@ var default_1 = (function () {
                                     }
                                     //ctx.invokeEvent('read', r);
                                     if (range) {
-                                        var rex = /([0-9]+)/g;
-                                        var min = parseInt(rex.exec(range)[1], 10);
-                                        var max = parseInt(rex.exec(range)[1], 10);
+                                        var match = /(\d+)-(\d+|)/.exec(range);
+                                        var min = match && match[1] ? parseInt(match[1], 10) : 0;
+                                        var max = match && match[2] ? parseInt(match[2], 10) : Infinity;
                                         ctx.setCode(WebDAVRequest_1.HTTPCodes.PartialContent);
                                         ctx.response.setHeader('Accept-Ranges', 'bytes');
                                         ctx.response.setHeader('Content-Type', mimeType);


### PR DESCRIPTION
Modified the range parsing lines in the Get command area. The expression `/(\d+)-(\d+|)/` captures a non-optional start parameter and an optional end parameter.

Edit: I use `webdav-server` in the tests for my client library [`webdav-client`](https://github.com/perry-mitchell/webdav-client) (`webdav` on npm). I've tested this update to work for the code I use [here](https://github.com/perry-mitchell/webdav-client/pull/55/files#diff-59102fb7c41ed2b630465587aa5a595aR22).