### PR TITLE
Fix an issue where an error 'e' is ignored after readdir.

### DIFF
--- a/src/server/v2/commands/Propfind.ts
+++ b/src/server/v2/commands/Propfind.ts
@@ -202,6 +202,9 @@ export default class implements HTTPMethod
                                 callback();
                             }
 
+                            if(e)
+                                return err(e);
+
                             addXMLInfo(resource, multistatus, (e) => {
                                 if(e)
                                     return err(e);


### PR DESCRIPTION
Hello,

There is an issue in Propfind method.
I have found which an error got by readdir's callback is ignored.
By this issue, WebDAV server crashes when I return error in readdir's callback.

Env:
- OS: Windows 7 Pro (x64)
- Node.JS: v6.10.0
- WebDAV-Server: v2.3.4

Thank you.