### PR TITLE
Move path decoding to string input

### DIFF
--- a/lib/manager/v2/Path.js
+++ b/lib/manager/v2/Path.js
@@ -7,13 +7,13 @@ var Path = (function () {
             var doubleIndex = void 0;
             while ((doubleIndex = sPath.indexOf('//')) !== -1)
                 sPath = sPath.substr(0, doubleIndex) + sPath.substr(doubleIndex + 1);
-            this.paths = sPath.replace(/(^\/|\/$)/g, '').split('/');
+            this.paths = sPath.replace(/(^\/|\/$)/g, '').split('/').map(decodeURIComponent);
         }
         else if (path.constructor === Path)
             this.paths = path.paths.filter(function (x) { return true; }); // clone
         else
             this.paths = path;
-        this.paths = this.paths.filter(function (p) { return p.length > 0; }).map(decodeURIComponent);
+        this.paths = this.paths.filter(function (p) { return p.length > 0; });
     }
     Path.prototype.isRoot = function () {
         return this.paths.length === 0 || this.paths.length === 1 && this.paths[0].length === 0;


### PR DESCRIPTION
I found an issue with path decoding, which made it impossible to get the content of folders with special characters in their names (like "text%20path" for example). I know it's a weird use case but it can happen.

I did this small fix in order to avoid decoding paths more than once, which can be problematic in this case when cloning or getting child path.

I just moved the decoding to the constructor for string only, which means it's only executed once. This seems to work fine from what I tested.