### PR TITLE
Multiply lock refresh * 1000 for milliseconds from seconds

### DIFF
--- a/src/resource/v2/lock/Lock.ts
+++ b/src/resource/v2/lock/Lock.ts
@@ -68,6 +68,6 @@ export class Lock
 
     refresh(timeout ?: number)
     {
-        this.expirationDate += (timeout ? timeout : this.lockKind.timeout) * 1000;
+        this.expirationDate = Date.now() + (timeout ? timeout : this.lockKind.timeout) * 1000;
     }
 }

--- a/src/resource/v2/lock/Lock.ts
+++ b/src/resource/v2/lock/Lock.ts
@@ -68,6 +68,6 @@ export class Lock
 
     refresh(timeout ?: number)
     {
-        this.expirationDate += timeout ? timeout : this.lockKind.timeout;
+        this.expirationDate += (timeout ? timeout : this.lockKind.timeout) * 1000;
     }
 }


### PR DESCRIPTION
Low priority because most will be fine with initial lock timeout of an hour, but for correctness it should be this.

Documentation also should explicitly say seconds, even though most would guess 3600 is seconds for an hour.