### PR TITLE
Improve respondWithPaths

### DIFF
--- a/src/server/v2/RequestContext.ts
+++ b/src/server/v2/RequestContext.ts
@@ -170,7 +170,7 @@ export class RequestContext
             uri = this.requested.uri;
 
         if(this.server.options.respondWithPaths)
-            return uri;
+            return this.rootPath ? this.rootPath + uri : uri;
         else
             return (this.prefixUri() + uri).replace(/([^:])\/\//g, '$1/');
     }


### PR DESCRIPTION
Fixes issue #67, wrong paths in propfind if respondWithPaths while mounted at subpath e.g. in Express.