### PR TITLE
Added user to context

### DIFF
--- a/src/server/v2/RequestContext.ts
+++ b/src/server/v2/RequestContext.ts
@@ -296,7 +296,7 @@ export class HTTPRequestContext extends RequestContext
                     return callback(Errors.MissingAuthorisationHeader, ctx);
 
                 server.getFileSystem(ctx.requested.path, (fs, _, subPath) => {
-                    fs.type(ctx.requested.path.isRoot() ? server.createExternalContext() : ctx, subPath, (e, type) => {
+                    fs.type(ctx.requested.path.isRoot() ? server.createExternalContext({user}) : ctx, subPath, (e, type) => {
                         if(e)
                             type = undefined;
 


### PR DESCRIPTION
ctx already contains user informations. But in case of path root, it use createExternalContext and don't pass user informations.