### PR TITLE
Fix Internal Server Error for move

### DIFF
--- a/src/manager/v2/instances/PhysicalFileSystem.ts
+++ b/src/manager/v2/instances/PhysicalFileSystem.ts
@@ -217,7 +217,7 @@ export class PhysicalFileSystem extends FileSystem
         const rename = (overwritten) => {
             fs.rename(realPathFrom, realPathTo, (e) => {
                 if(e)
-                    return callback(e);
+                    return callback(Errors_1.Errors.ResourceNotFound);
 
                 this.resources[realPathTo] = this.resources[realPathFrom];
                 delete this.resources[realPathFrom];


### PR DESCRIPTION
A move command on a none existing file results in a 500.
This change fixes it so that it returns a 404 instead.