### PR TITLE
fix crash when invalid request sent to the server

### DIFF
--- a/src/manager/v2/Path.ts
+++ b/src/manager/v2/Path.ts
@@ -28,7 +28,12 @@ export class Path
 
     decode() : void
     {
-        this.paths = this.paths.map(decodeURIComponent);
+        // FIX: crash when paths contains invalid path, example '%NETHOOD%'
+        try {
+            this.paths = this.paths.map(decodeURIComponent);
+        } catch (e) {
+            console.log(e)
+        }
     }
 
     isRoot() : boolean


### PR DESCRIPTION
In some network environment, some special URL request was sent to the server and it will crash. It is suggested to just ignore the error and let the server keep working.

Thanks,
Shenghong