### PR TITLE
fix a bad conditional that was preventing evaluation of If header tokens

### DIFF
--- a/src/helper/v2/IfParser.ts
+++ b/src/helper/v2/IfParser.ts
@@ -82,7 +82,7 @@ function parseInternal(group : string)
         match = rex.exec(group);
     }
 
-    if(andArray.length)
+    if(andArray.length == 0)
         return (r, callback) => callback(null, true);
 
     return function(resource : Resource, callback : FnReturn) {


### PR DESCRIPTION
If a resource is locked, any request bearing a `If: (<DAV:no-lock>)` header would still get through because of this.

I couldn't find a way to unit-test this behavior but it doesn't break any existing tests.