### PR TITLE
Return total file size for Content-Range instead of *

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "editor.formatOnSave": false
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "editor.formatOnSave": false
-}

--- a/src/manager/v2/fileSystem/FileSystem.ts
+++ b/src/manager/v2/fileSystem/FileSystem.ts
@@ -2027,7 +2027,7 @@ export abstract class FileSystem implements ISerializableFileSystem
                 .each(Object.keys(tree), (name, cb) => {
                     const value = tree[name];
                     const childPath = rootPath.getChildPath(name);
-                    if(value.constructor === ResourceType || value.constructor === String || value.constructor === Buffer)
+                    if(value.constructor === ResourceType || typeof value === 'string' || value.constructor === Buffer)
                     {
                         this.addSubTree(ctx, childPath, value, cb)
                     }

--- a/src/manager/v2/fileSystem/Resource.ts
+++ b/src/manager/v2/fileSystem/Resource.ts
@@ -9,7 +9,7 @@ import {
 import { Readable, Writable } from 'stream'
 import { IPropertyManager } from './PropertyManager'
 import { RequestContext } from '../../../server/v2/RequestContext'
-import { ILockManager, ILockManagerAsync } from './LockManager'
+import { ILockManagerAsync } from './LockManager'
 import { FileSystem } from './FileSystem'
 import { LockKind } from '../../../resource/v2/lock/LockKind'
 import { Lock } from '../../../resource/v2/lock/Lock'

--- a/src/resource/v1/physical/PhysicalGateway.ts
+++ b/src/resource/v1/physical/PhysicalGateway.ts
@@ -16,7 +16,7 @@ export class PhysicalGateway extends PhysicalFolder
         [path : string] : PhysicalResource
     }
 
-    constructor(rootPath : string, protected customName ?: string, parent ?: IResource, fsManager ?: FSManager)
+    constructor(rootPath : string, public customName ?: string, parent ?: IResource, fsManager ?: FSManager)
     {
         super(rootPath, parent, fsManager ? fsManager : new PhysicalGFSManager());
 

--- a/src/server/v1/commands/Get.ts
+++ b/src/server/v1/commands/Get.ts
@@ -91,18 +91,26 @@ export function method(arg : MethodCallArgs, callback)
                                     const range = arg.findHeader('Range');
                                     if(range)
                                     {
-                                        const rex = /([0-9]+)/g;
-                                        const min = parseInt(rex.exec(range)[1], 10);
-                                        const max = parseInt(rex.exec(range)[1], 10);
+                                        r.size(targetSource, (e, totalSize) => {
+                                            if(e)
+                                            {
+                                                arg.setCode(HTTPCodes.InternalServerError)
+                                                callback();
+                                                return;
+                                            }
+                                            const rex = /([0-9]+)/g;
+                                            const min = parseInt(rex.exec(range)[1], 10);
+                                            const max = parseInt(rex.exec(range)[1], 10);
 
-                                        arg.setCode(HTTPCodes.PartialContent);
-                                        arg.response.setHeader('Accept-Ranges', 'bytes')
-                                        arg.response.setHeader('Content-Type', mimeType)
-                                        arg.response.setHeader('Content-Length', (max - min).toString())
-                                        arg.response.setHeader('Content-Range', 'bytes ' + min + '-' + max + '/'+ (max - min).toString())
+                                            arg.setCode(HTTPCodes.PartialContent);
+                                            arg.response.setHeader('Accept-Ranges', 'bytes')
+                                            arg.response.setHeader('Content-Type', mimeType)
+                                            arg.response.setHeader('Content-Length', (max - min).toString())
+                                            arg.response.setHeader('Content-Range', 'bytes ' + min + '-' + max + '/'+totalSize.toString())
 
-                                        rstream.on('end', callback);
-                                        rstream.pipe(new RangedStream(min, max)).pipe(arg.response);
+                                            rstream.on('end', callback);
+                                            rstream.pipe(new RangedStream(min, max)).pipe(arg.response);
+                                        });
                                     }
                                     else
                                     {

--- a/src/server/v1/commands/Get.ts
+++ b/src/server/v1/commands/Get.ts
@@ -99,7 +99,7 @@ export function method(arg : MethodCallArgs, callback)
                                         arg.response.setHeader('Accept-Ranges', 'bytes')
                                         arg.response.setHeader('Content-Type', mimeType)
                                         arg.response.setHeader('Content-Length', (max - min).toString())
-                                        arg.response.setHeader('Content-Range', 'bytes ' + min + '-' + max + '/*')
+                                        arg.response.setHeader('Content-Range', 'bytes ' + min + '-' + max + '/'+ (max - min).toString())
 
                                         rstream.on('end', callback);
                                         rstream.pipe(new RangedStream(min, max)).pipe(arg.response);

--- a/src/server/v2/commands/Get.ts
+++ b/src/server/v2/commands/Get.ts
@@ -216,7 +216,7 @@ export default class implements HTTPMethod
                                                 if(ranges.length <= 1)
                                                 {
                                                     ctx.response.setHeader('Content-Type', mimeType)
-                                                    ctx.response.setHeader('Content-Range', `bytes ${ranges[0].min}-${ranges[0].max}/${len.toString()}`)
+                                                    ctx.response.setHeader('Content-Range', `bytes ${ranges[0].min}-${ranges[0].max}/${size}`)
                                                     rstream.on('end', callback);
                                                     return rstream.pipe(new RangedStream(ranges[0].min, ranges[0].max)).pipe(ctx.response);
                                                 }

--- a/src/server/v2/commands/Get.ts
+++ b/src/server/v2/commands/Get.ts
@@ -216,7 +216,7 @@ export default class implements HTTPMethod
                                                 if(ranges.length <= 1)
                                                 {
                                                     ctx.response.setHeader('Content-Type', mimeType)
-                                                    ctx.response.setHeader('Content-Range', `bytes ${ranges[0].min}-${ranges[0].max}/*`)
+                                                    ctx.response.setHeader('Content-Range', `bytes ${ranges[0].min}-${ranges[0].max}/${len.toString()}`)
                                                     rstream.on('end', callback);
                                                     return rstream.pipe(new RangedStream(ranges[0].min, ranges[0].max)).pipe(ctx.response);
                                                 }

--- a/src/server/v2/commands/Head.ts
+++ b/src/server/v2/commands/Head.ts
@@ -52,7 +52,7 @@ export default class implements HTTPMethod
                                             if(ranges.length <= 1)
                                             {
                                                 ctx.response.setHeader('Content-Type', mimeType)
-                                                ctx.response.setHeader('Content-Range', `bytes ${ranges[0].min}-${ranges[0].max}/${len.toString()}`)
+                                                ctx.response.setHeader('Content-Range', `bytes ${ranges[0].min}-${ranges[0].max}/${size}`)
                                             }
                                             else
                                                 ctx.response.setHeader('Content-Type', `multipart/byteranges; boundary=${separator}`)

--- a/src/server/v2/commands/Head.ts
+++ b/src/server/v2/commands/Head.ts
@@ -52,7 +52,7 @@ export default class implements HTTPMethod
                                             if(ranges.length <= 1)
                                             {
                                                 ctx.response.setHeader('Content-Type', mimeType)
-                                                ctx.response.setHeader('Content-Range', `bytes ${ranges[0].min}-${ranges[0].max}/*`)
+                                                ctx.response.setHeader('Content-Range', `bytes ${ranges[0].min}-${ranges[0].max}/${len.toString()}`)
                                             }
                                             else
                                                 ctx.response.setHeader('Content-Type', `multipart/byteranges; boundary=${separator}`)


### PR DESCRIPTION
If the client loads a file range using the range header, webdav-server returns correct data with the Content-Range response header.

Before:
```Content-Range: 0-1024/*```

The asterisk (*) is allowed according to http specs instead of returning the total file size. But some clients (like the [pdftools.com](https://www.pdf-tools.com) PDF Web Viewer) require the real file size to work. This pr changes the behavior to return the file size like:

Now:
```Content-Range: 0-1024/4000```

I've also needed to change some stuff for TypeScript to work. 