### PR TITLE
Use `string` instead of `String`

### DIFF
--- a/src/manager/v2/Path.ts
+++ b/src/manager/v2/Path.ts
@@ -10,18 +10,18 @@ export class Path
 
     constructor(path : Path | string[] | string)
     {
-        if(path.constructor === String)
+        if(typeof path === "string")
         {
-            let sPath = path as string;
+            let sPath = path;
             let doubleIndex : number;
             while((doubleIndex = sPath.indexOf('//')) !== -1)
-                sPath = sPath.substr(0, doubleIndex) + sPath.substr(doubleIndex + 1);
+                sPath = sPath.slice(0, doubleIndex) + sPath.slice(doubleIndex + 1);
             this.paths = sPath.replace(/(^\/|\/$)/g, '').split('/');
         }
-        else if(path.constructor === Path)
-            this.paths = (path as Path).paths.filter((x) => true); // clone
+        else if(Array.isArray(path))
+            this.paths = path;
         else
-            this.paths = path as string[];
+            this.paths = path.paths.slice(0); // clone
         
         this.paths = this.paths.filter((p) => p.length > 0);
     }

--- a/src/manager/v2/fileSystem/FileSystem.ts
+++ b/src/manager/v2/fileSystem/FileSystem.ts
@@ -628,7 +628,7 @@ export abstract class FileSystem implements ISerializableFileSystem
             if(obj && obj.constructor === Function)
                 callbackFinal = obj as Return2Callback<Writable, boolean>;
         
-        const mode = _mode && _mode.constructor === String ? _mode as OpenWriteStreamMode : 'mustExist';
+        const mode: OpenWriteStreamMode = _mode && typeof _mode === "string" ? _mode : 'mustExist';
         const path = new Path(_path);
         let created = false;
 
@@ -1677,7 +1677,7 @@ export abstract class FileSystem implements ISerializableFileSystem
                         if(paths.length === 0)
                             return callback(null, base);
                         
-                        if(paths[0].constructor === String)
+                        if(typeof paths[0] === "string")
                             base = base.concat((paths as string[]).map((s) => pPath.getChildPath(s)));
                         else
                             base = base.concat(paths as Path[]);
@@ -2005,9 +2005,9 @@ export abstract class FileSystem implements ISerializableFileSystem
         {
             this.create(ctx, rootPath, tree as ResourceType, callback);
         }
-        else if(tree.constructor === String || tree.constructor === Buffer)
+        else if(typeof tree === "string" || tree.constructor === Buffer)
         {
-            const data : String | Buffer = tree as any;
+            const data : string | Buffer = tree as any;
             this.openWriteStream(ctx, rootPath, 'mustCreate', true, data.length, (e, w, created) => {
                 if(e)
                     return callback(e);
@@ -2027,7 +2027,7 @@ export abstract class FileSystem implements ISerializableFileSystem
                 .each(Object.keys(tree), (name, cb) => {
                     const value = tree[name];
                     const childPath = rootPath.getChildPath(name);
-                    if(value.constructor === ResourceType || value.constructor === String || value.constructor === Buffer)
+                    if(value.constructor === ResourceType || typeof value === "string" || value.constructor === Buffer)
                     {
                         this.addSubTree(ctx, childPath, value, cb)
                     }
@@ -2286,8 +2286,8 @@ export abstract class FileSystem implements ISerializableFileSystem
     checkPrivilege(ctx : RequestContext, path : Path | string, privileges : string | string[], callback : ReturnCallback<boolean>)
     checkPrivilege(ctx : RequestContext, path : Path | string, privileges : string | string[] | BasicPrivilege | BasicPrivilege[], callback : ReturnCallback<boolean>)
     {
-        if(privileges.constructor === String)
-            privileges = [ privileges as string ];
+        if(typeof privileges === "string")
+            privileges = [ privileges ];
         
         this.getFullPath(ctx, path, (e, fullPath) => {
             this.privilegeManager(ctx, path, (e, privilegeManager) => {

--- a/src/manager/v2/fileSystem/StorageManager.ts
+++ b/src/manager/v2/fileSystem/StorageManager.ts
@@ -88,8 +88,8 @@ export class PerUserStorageManager implements IStorageManager
     {
         if(!value)
             return 0;
-        if(value.constructor === String)
-            return (value as String).length;
+        if(typeof value === "string")
+            return value.length;
         if(Array.isArray(value))
             return (value as XMLElement[]).map((el) => this.evalPropValue(el)).reduce((p, n) => p + n, 0);
 

--- a/src/resource/v2/lock/Lock.ts
+++ b/src/resource/v2/lock/Lock.ts
@@ -53,7 +53,7 @@ export class Lock
         this.owner = owner;
         this.depth = depth === undefined || depth === null ? -1 : depth;
         this.uuid = Lock.generateUUID(this.expirationDate);
-        this.userUid = user ? user.constructor === String ? user as string : (user as IUser).uid : null;
+        this.userUid = user ? typeof user === "string" ? user : user.uid : null;
     }
 
     isSame(lock : Lock) : boolean

--- a/src/server/v2/commands/Propfind.ts
+++ b/src/server/v2/commands/Propfind.ts
@@ -188,7 +188,7 @@ export default class implements HTTPMethod
 
         function displayValue(values : string[] | string, fn : () => void)
         {
-            if(values.constructor === String ? tags[values as string].value : (values as string[]).some((n) => tags[n].value))
+            if(typeof values === "string" ? tags[values].value : values.some((n) => tags[n].value))
             {
                 ++nb;
                 process.nextTick(fn);

--- a/src/server/v2/webDAVServer/StartStop.ts
+++ b/src/server/v2/webDAVServer/StartStop.ts
@@ -45,8 +45,8 @@ export function executeRequest(req : http.IncomingMessage, res : http.ServerResp
                 const data = Buffer.alloc(base.headers.contentLength);
                 let index = 0;
                 req.on('data', (chunk) => {
-                    if(chunk.constructor === String)
-                        chunk = Buffer.from(chunk as string);
+                    if(typeof chunk === "string")
+                        chunk = Buffer.from(chunk);
                     
                     for(let i = 0; i < chunk.length && index < data.length; ++i, ++index)
                         data[index] = (chunk as Buffer)[i];

--- a/src/server/v2/webDAVServer/WebDAVServer.ts
+++ b/src/server/v2/webDAVServer/WebDAVServer.ts
@@ -272,9 +272,9 @@ export class WebDAVServer
     removeFileSystemSync(fs_path : Path | string | FileSystem, checkByReference : boolean = true) : number
     {
         let nb = 0;
-        if(fs_path.constructor === Path || fs_path.constructor === String)
+        if(fs_path.constructor === Path || typeof fs_path === "string")
         {
-            const path = new Path(fs_path as (Path | string)).toString();
+            const path = new Path(fs_path).toString();
             if(this.fileSystems[path] !== undefined)
             {
                 delete this.fileSystems[path];
@@ -725,7 +725,7 @@ export class WebDAVServer
         if(!this.events[event])
             return;
 
-        this.events[event].forEach((l) => process.nextTick(() => l(ctx, fs, path.constructor === String ? new Path(path as string) : path as Path, data)));
+        this.events[event].forEach((l) => process.nextTick(() => l(ctx, fs, typeof path === "string" ? new Path(path) : path, data)));
     }
 
     /**

--- a/src/user/v2/privilege/PrivilegeManager.ts
+++ b/src/user/v2/privilege/PrivilegeManager.ts
@@ -39,7 +39,7 @@ export class PrivilegeManager
         if(resource.context.overridePrivileges || user && user.isAdministrator)
             return callback(null, true);
         
-        if(_privilege.constructor !== String)
+        if(typeof _privilege !== "string")
         {
             new Workflow()
                 .each(_privilege as string[], (privilege, cb) => this.can(_fullPath, resource, privilege, cb))

--- a/test/v2/root.js
+++ b/test/v2/root.js
@@ -131,7 +131,7 @@ module.exports = (callback, options) => {
 
                             if(name !== undefined)
                             {
-                                if(name.constructor === String)
+                                if(typeof name === "string")
                                 {
                                     info.name = name;
                                     info.startServer(undefined, autoStart);


### PR DESCRIPTION
Fixes #126

Maybe TypeScript has become stricter or just changed.
The class `String` is not the same as the native type `string`. Because the code doesn't seem to require `String` anywhere, I'm only testing for the native type `string` now, which also fixes #126.