### PR TITLE
BufferEncoding: UTF-8 -> utf-8

### DIFF
--- a/src/server/v2/RequestContext.ts
+++ b/src/server/v2/RequestContext.ts
@@ -385,14 +385,14 @@ export class HTTPRequestContext extends RequestContext
             case 'xml':
                 this.response.setHeader('Content-Type', 'application/xml;charset=utf-8');
                 this.response.setHeader('Content-Length', Buffer.from(content).length.toString());
-                this.response.write(content, 'UTF-8');
+                this.response.write(content, 'utf-8');
                 break;
                 
             case 'json':
                 content = XML.toJSON(content);
                 this.response.setHeader('Content-Type', 'application/json;charset=utf-8');
                 this.response.setHeader('Content-Length', Buffer.from(content).length.toString());
-                this.response.write(content, 'UTF-8');
+                this.response.write(content, 'utf-8');
                 break;
         }
 


### PR DESCRIPTION
`UTF-8` is not an official alias for `utf8`, but `uft-8` is.

https://nodejs.org/api/buffer.html#buffers-and-character-encodings